### PR TITLE
Color enhancements and dotted lines

### DIFF
--- a/components/map/pixi-overlay-component.tsx
+++ b/components/map/pixi-overlay-component.tsx
@@ -438,7 +438,8 @@ const PixiOverlayComponent = ({
         //update the drifters
 
         //Change the scale of the circles for improve zoom
-        updateCircleLocations(Math.max(scale, 1))
+        updateCircleLocations(Math.max(scale * 2, 1))
+        // updateCircleLocations(1)
 
         updateLineBoldness(scale, zoom)
 

--- a/components/map/pixi-overlay-component.tsx
+++ b/components/map/pixi-overlay-component.tsx
@@ -107,11 +107,11 @@ const PixiOverlayComponent = ({
   const updateLineBoldness = useEffectEvent((scale: number, zoom: number) => {
     const lineWidth = zoom > 10 ? 2 / scale : 3
     console.log("zoom", zoom)
-    const showArrowHeads = false
+    const showDottedLine = zoom > 11
 
     lazybatchApply(
       lineGraphics.current.concat(backgroundLineGraphics.current),
-      (v) => v.setArrowHeadVisibility(showArrowHeads)
+      (v) => v.setDottedLineVisibility(showDottedLine)
     )
     //Update drawn lines
     if (zoom > 10 || firstDraw) {
@@ -129,7 +129,7 @@ const PixiOverlayComponent = ({
         line.clear()
 
         line.lineStyle({ width: lineWidth, alpha: 0.3 })
-        line.lineGraphic.tint = "magenta"
+        line.lineGraphic.tint = theme === "dark" ? "magenta" : "purple"
         line.drawVertices()
       })
     }
@@ -182,6 +182,7 @@ const PixiOverlayComponent = ({
           width: 3,
         })
         line.lineGraphic.tint = color
+        line.dottedLineGraphic.tint = color
         line.visible = isBackground || false
 
         return line

--- a/components/map/sprites/line.ts
+++ b/components/map/sprites/line.ts
@@ -32,9 +32,8 @@ export class DrifterPath extends Container {
   isBackground: boolean
 
   linePoints: IPointData[]
-  arrowAngles: number[]
   lineGraphic: Graphics
-  arrowTexture: RenderTexture
+  dottedLineGraphic: Graphics
 
   constructor(
     _linePoints: IPointData[],
@@ -54,78 +53,63 @@ export class DrifterPath extends Container {
       color: "white",
       alpha: this.isBackground ? 0.3 : 1,
     })
-
     this.lineGraphic.tint = this.isBackground
       ? backgroundLineColor
       : defaultLineColor
 
+    this.dottedLineGraphic = new Graphics()
+    this.dottedLineGraphic.lineStyle({
+      width: 3,
+      color: "#A6A09B",
+    })
+
+    this.dottedLineGraphic.lineTextureStyle
+
     this.visible = this.isBackground
 
     this.addChild(this.lineGraphic)
-
-    this.arrowAngles = this.linePoints.map((_, index): number => {
-      const currentIndex = Math.min(index, this.linePoints.length - 2)
-      const { x, y } = this.linePoints[currentIndex]
-      const nextLocation = this.linePoints[currentIndex + 1]
-
-      const dx = nextLocation.x - x
-      const dy = nextLocation.y - y
-
-      return Math.atan2(dy, dx)
-    })
-
-    const arrowHead = new Graphics()
-    arrowHead.interactive = false
-    arrowHead.beginFill(this.lineGraphic.line.color)
-    arrowHead.drawPolygon(transformedArrow)
-    arrowHead.endFill()
-    this.arrowTexture = renderer.generateTexture(arrowHead)
-
-    arrowHead.destroy()
-
-    if (!this.isBackground) this.addArrowHeads()
+    this.addChild(this.dottedLineGraphic)
   }
 
   clear() {
     this.lineGraphic.clear()
+    this.dottedLineGraphic.clear()
   }
 
   setIsDark(isDark: boolean): void {
     this.lineGraphic.tint = isDark ? "lime" : "darkgreen"
+    this.dottedLineGraphic.tint = isDark ? "lime" : "darkgreen"
   }
 
   lineStyle(style: Pick<ILineStyleOptions, "alpha" | "width">) {
     this.lineGraphic.lineStyle({ ...style, color: "white" })
+    this.dottedLineGraphic.lineStyle({ ...style, color: "#A6A09B" })
 
-    const scale = (style.width || 3) / 3
-    this.children.slice(1).forEach((v) => v.scale.set(scale))
+    // const scale = (style.width || 3) / 3
+    // this.children.slice(1).forEach((v) => v.scale.set(scale))
   }
 
-  setArrowHeadVisibility(visible: boolean) {
-    this.children.slice(1).forEach((v) => (v.renderable = visible))
-  }
-
-  private addArrowHeads() {
-    this.linePoints.forEach(({ x, y }, frame) => {
-      if (frame % 5 === 0) {
-        const arrow = new Sprite(this.arrowTexture)
-        arrow.eventMode = "none"
-        const angle = this.arrowAngles[frame - 1]
-        arrow.setTransform(x, y, 0.05, 0.05, angle)
-        arrow.anchor.set(0.5)
-
-        this.addChild(arrow)
-      }
-    })
+  setDottedLineVisibility(visible: boolean) {
+    // this.children.slice(1).forEach((v) => (v.renderable = visible))
+    this.dottedLineGraphic.visible = visible
   }
 
   drawVertices() {
     this.linePoints.forEach(({ x, y }, frame) => {
       if (frame === 0) {
         this.lineGraphic.moveTo(x, y)
+
         this.lineGraphic.drawCircle(x, y, this.lineGraphic.line.width * 2)
+
+        this.dottedLineGraphic.moveTo(x, y)
       } else {
         this.lineGraphic.lineTo(x, y)
+
+        if (frame % 2 === 1) {
+          this.dottedLineGraphic.lineTo(x, y)
+        } else {
+          this.dottedLineGraphic.moveTo(x, y)
+        }
       }
     })
   }

--- a/components/map/sprites/line.ts
+++ b/components/map/sprites/line.ts
@@ -77,8 +77,13 @@ export class DrifterPath extends Container {
   }
 
   setIsDark(isDark: boolean): void {
-    this.lineGraphic.tint = isDark ? "lime" : "darkgreen"
-    this.dottedLineGraphic.tint = isDark ? "lime" : "darkgreen"
+    if (this.isBackground) {
+      this.lineGraphic.tint = isDark ? "magenta" : "purple"
+      this.dottedLineGraphic.tint = isDark ? "magenta" : "purple"
+    } else {
+      this.lineGraphic.tint = isDark ? "lime" : "darkgreen"
+      this.dottedLineGraphic.tint = isDark ? "lime" : "darkgreen"
+    }
   }
 
   lineStyle(style: Pick<ILineStyleOptions, "alpha" | "width">) {


### PR DESCRIPTION
# Replace solid-line arrowheads with a dotted overlay for drifter paths

## Summary

This PR removes the arrow-head sprite rendering on drifter track lines and replaces it with a separate dotted line overlay drawn directly with PixiJS's `Graphics` API. The dotted overlay is toggled based on zoom level rather than always rendered, and several color/theming tweaks are layered in alongside it.

---

## `DrifterPath` — `line.ts`

### Removed: arrow-head sprite system

The previous implementation pre-computed an `arrowAngles` array (the heading between each consecutive pair of points via `Math.atan2`), rendered a single arrow shape to a `RenderTexture`, and stamped a `Sprite` of that texture at every 5th frame along the line, rotated to match the local heading. All of this — `arrowAngles`, `arrowTexture`, `addArrowHeads()`, and `setArrowHeadVisibility()` — has been removed.

### Added: `dottedLineGraphic`

In its place, `DrifterPath` now holds a second `Graphics` object, `dottedLineGraphic`, alongside the existing solid `lineGraphic`. It's styled with a 3px stroke in `#A6A09B` and added as a second child of the container.

`drawVertices()` now draws both lines in the same pass over `linePoints`: the solid line is drawn continuously as before, while the dotted line alternates between `lineTo` and `moveTo` every other frame (`frame % 2 === 1`), which produces a dashed appearance using only native Pixi line drawing rather than a sprite-based texture trick.

`clear()`, `lineStyle()`, and `setIsDark()` are all updated to operate on both graphics objects. Note that `setIsDark()` now also branches on `isBackground`, applying magenta/purple to background lines and lime/darkgreen to foreground lines — previously it only handled the foreground case.

The visibility toggle is renamed from `setArrowHeadVisibility` to `setDottedLineVisibility`, and now simply sets `dottedLineGraphic.visible` instead of iterating over child sprites.

---

## `PixiOverlayComponent` — zoom-driven dotted line visibility

`updateLineBoldness` previously hardcoded `showArrowHeads = false`, meaning arrowheads were always hidden regardless of zoom. This is replaced with `showDottedLine = zoom > 11`, so the dotted overlay only becomes visible once the user has zoomed in past level 11, and `setDottedLineVisibility` is called instead of the old `setArrowHeadVisibility`.

Two related changes:
- Background line tint now respects the current theme: `theme === "dark" ? "magenta" : "purple"` instead of always `"magenta"`.
- When a new `DrifterPath` is constructed, `dottedLineGraphic.tint` is now also set to the drifter's assigned color, matching the existing `lineGraphic.tint` assignment.
- Drifter circle scaling on zoom is doubled: `updateCircleLocations(Math.max(scale * 2, 1))`, replacing `Math.max(scale, 1)`, making the drifter markers more prominent at a given zoom level.

---

## Net Effect

Drifter paths now render as a solid line with a secondary dotted line drawn over it, visible only at closer zoom levels, instead of periodic directional arrow sprites. This avoids the texture-generation and sprite-instantiation overhead of the arrow approach while still giving a visual cue of motion/direction along the path, and ties better into light/dark theme switching.